### PR TITLE
feat: 빌링키 삭제 API 요청 파라미터 reason, extra[requester] 지원하도록 수정

### DIFF
--- a/example/subscribe/customerDelete.php
+++ b/example/subscribe/customerDelete.php
@@ -4,11 +4,14 @@ require_once '../../vendor/autoload.php';
 
 use Iamport\RestClient\Iamport;
 use Iamport\RestClient\Request\Subscribe\SubscribeCustomer;
+use Iamport\RestClient\Request\Subscribe\SubscribeCustomerExtra;
 
 $iamport = new Iamport('imp_apikey', 'ekKoeW8RyKuT0zgaZsUtXXTLQ4AhPFW3ZGseDA6bkA5lamv9OqDMnxyeB9wqOsuO9W3Mx9YSJ4dTqJ3f');
 
 // 비인증결제 빌링키 삭제
-$request = SubscribeCustomer::delete('구매자 고유번호(customerUid)');
+$extra = new SubscribeCustomerExtra();
+$extra->requester = '삭제 요청자';
+$request = SubscribeCustomer::delete('구매자 고유번호(customerUid)', '삭제 사유', $extra);
 $result  = $iamport->callApi($request);
 
 if ($result->isSuccess()) {

--- a/example/subscribe/customerDelete.php
+++ b/example/subscribe/customerDelete.php
@@ -9,9 +9,10 @@ use Iamport\RestClient\Request\Subscribe\SubscribeCustomerExtra;
 $iamport = new Iamport('imp_apikey', 'ekKoeW8RyKuT0zgaZsUtXXTLQ4AhPFW3ZGseDA6bkA5lamv9OqDMnxyeB9wqOsuO9W3Mx9YSJ4dTqJ3f');
 
 // 비인증결제 빌링키 삭제
-$extra = new SubscribeCustomerExtra();
+$reason = "삭제 사유"; // Optional 요청 파라미터.
+$extra = new SubscribeCustomerExtra(); // Optional 요청 파라미터.
 $extra->requester = '삭제 요청자';
-$request = SubscribeCustomer::delete('구매자 고유번호(customerUid)', '삭제 사유', $extra);
+$request = SubscribeCustomer::delete('구매자 고유번호(customerUid)', $reason, $extra);
 $result  = $iamport->callApi($request);
 
 if ($result->isSuccess()) {

--- a/src/Request/Subscribe/SubscribeCustomer.php
+++ b/src/Request/Subscribe/SubscribeCustomer.php
@@ -27,6 +27,8 @@ use InvalidArgumentException;
  * @property mixed  $from
  * @property mixed  $to
  * @property string $schedule_status
+ * @property string $reason
+ * @property string $extra_requester
  */
 class SubscribeCustomer extends RequestBase
 {
@@ -118,6 +120,16 @@ class SubscribeCustomer extends RequestBase
     protected $schedule_status;
 
     /**
+     * @var string 삭제 사유
+     */
+    protected $reason;
+
+    /**
+     * @var string 삭제 요청자(네이버페이에서만 사용)
+     */
+    protected $extra_requester;
+
+    /**
      * SubscribeCustomer constructor.
      */
     public function __construct()
@@ -138,7 +150,8 @@ class SubscribeCustomer extends RequestBase
         $instance->verb          = 'GET';
         $instance->unsetArray([
             'customer_uids', 'pg', 'card_number', 'expiry', 'birth', 'pwd_2digit', 'customer_name', 'customer_tel',
-            'customer_email', 'customer_addr', 'customer_postcode', 'page', 'from', 'to', 'schedule-status',
+            'customer_email', 'customer_addr', 'customer_postcode', 'page', 'from', 'to', 'schedule-status', 'reason',
+            'extra_requester',
         ]);
 
         return $instance;
@@ -163,7 +176,7 @@ class SubscribeCustomer extends RequestBase
         $instance->responseClass = Response\SubscribeCustomer::class;
         $instance->instanceType  = 'issue';
         $instance->verb          = 'POST';
-        $instance->unsetArray(['customer_uids', 'page', 'from', 'to', 'schedule-status']);
+        $instance->unsetArray(['customer_uids', 'page', 'from', 'to', 'schedule-status', 'reason', 'extra_requester']);
 
         return $instance;
     }
@@ -173,10 +186,12 @@ class SubscribeCustomer extends RequestBase
      *
      * @return SubscribeCustomer
      */
-    public static function delete(string $customer_uid)
+    public static function delete(string $customer_uid, string $reason=null, string $extraRequester=null)
     {
         $instance                = new self();
         $instance->customer_uid  = $customer_uid;
+        $instance->reason = $reason;
+        $instance->extra_requester = $extraRequester;
         $instance->responseClass = Response\SubscribeCustomer::class;
         $instance->instanceType  = 'delete';
         $instance->verb          = 'DELETE';
@@ -203,7 +218,8 @@ class SubscribeCustomer extends RequestBase
         $instance->verb           = 'GET';
         $instance->unsetArray([
             'pg', 'card_number', 'expiry', 'birth', 'pwd_2digit', 'customer_name', 'customer_tel',
-            'customer_email', 'customer_addr', 'customer_postcode', 'page', 'from', 'to', 'schedule-status',
+            'customer_email', 'customer_addr', 'customer_postcode', 'page', 'from', 'to', 'schedule-status', 'reason',
+            'extra_requester',
         ]);
 
         return $instance;
@@ -225,7 +241,8 @@ class SubscribeCustomer extends RequestBase
         $instance->verb           = 'GET';
         $instance->unsetArray([
             'customer_uids', 'pg', 'card_number', 'expiry', 'birth', 'pwd_2digit', 'customer_name', 'customer_tel',
-            'customer_email', 'customer_addr', 'customer_postcode', 'from', 'to', 'schedule-status',
+            'customer_email', 'customer_addr', 'customer_postcode', 'from', 'to', 'schedule-status', 'reason',
+            'extra_requester',
         ]);
 
         return $instance;
@@ -252,7 +269,7 @@ class SubscribeCustomer extends RequestBase
         $instance->verb           = 'GET';
         $instance->unsetArray([
             'customer_uids', 'pg', 'card_number', 'expiry', 'birth', 'pwd_2digit', 'customer_name',
-            'customer_tel', 'customer_email', 'customer_addr', 'customer_postcode',
+            'customer_tel', 'customer_email', 'customer_addr', 'customer_postcode', 'reason', 'extra_requester',
         ]);
 
         return $instance;
@@ -326,6 +343,16 @@ class SubscribeCustomer extends RequestBase
         $this->schedule_status = $schedule_status;
     }
 
+    public function setReason(string $reason): void
+    {
+        $this->reason = $reason;
+    }
+
+    public function setExtraRequester(string $extra_requester): void
+    {
+        $this->extra_requester = $extra_requester;
+    }
+
     /**
      * 구매자의 빌링키 정보 조회
      * [GET] /subscribe/customers/{customer_uid}.
@@ -362,8 +389,20 @@ class SubscribeCustomer extends RequestBase
     {
         switch ($this->instanceType) {
             case 'view':
+                return [];
+                break;
             case 'delete':
-                return  [];
+                $result = ['query' => []];
+
+                if (!empty($this->reason)) {
+                    $result['query']['reason'] = $this->reason;
+                }
+
+                if (!empty($this->extra_requester)) {
+                    $result['query']['extra[requester]'] = $this->extra_requester;
+                }
+
+                return $result;
                 break;
             case 'issue':
                 return [

--- a/src/Request/Subscribe/SubscribeCustomer.php
+++ b/src/Request/Subscribe/SubscribeCustomer.php
@@ -28,7 +28,7 @@ use InvalidArgumentException;
  * @property mixed  $to
  * @property string $schedule_status
  * @property string $reason
- * @property string $extra_requester
+ * @property SubscribeCustomerExtra $extra
  */
 class SubscribeCustomer extends RequestBase
 {

--- a/src/Request/Subscribe/SubscribeCustomer.php
+++ b/src/Request/Subscribe/SubscribeCustomer.php
@@ -125,9 +125,9 @@ class SubscribeCustomer extends RequestBase
     protected $reason;
 
     /**
-     * @var string 삭제 요청자(네이버페이에서만 사용)
+     * @var SubscribeCustomerExtra
      */
-    protected $extra_requester;
+    protected $extra;
 
     /**
      * SubscribeCustomer constructor.
@@ -151,7 +151,7 @@ class SubscribeCustomer extends RequestBase
         $instance->unsetArray([
             'customer_uids', 'pg', 'card_number', 'expiry', 'birth', 'pwd_2digit', 'customer_name', 'customer_tel',
             'customer_email', 'customer_addr', 'customer_postcode', 'page', 'from', 'to', 'schedule-status', 'reason',
-            'extra_requester',
+            'extra',
         ]);
 
         return $instance;
@@ -176,7 +176,7 @@ class SubscribeCustomer extends RequestBase
         $instance->responseClass = Response\SubscribeCustomer::class;
         $instance->instanceType  = 'issue';
         $instance->verb          = 'POST';
-        $instance->unsetArray(['customer_uids', 'page', 'from', 'to', 'schedule-status', 'reason', 'extra_requester']);
+        $instance->unsetArray(['customer_uids', 'page', 'from', 'to', 'schedule-status', 'reason', 'extra']);
 
         return $instance;
     }
@@ -186,12 +186,12 @@ class SubscribeCustomer extends RequestBase
      *
      * @return SubscribeCustomer
      */
-    public static function delete(string $customer_uid, string $reason=null, string $extraRequester=null)
+    public static function delete(string $customer_uid, string $reason=null, SubscribeCustomerExtra $extra=null)
     {
         $instance                = new self();
         $instance->customer_uid  = $customer_uid;
-        $instance->reason = $reason;
-        $instance->extra_requester = $extraRequester;
+        $instance->reason        = $reason;
+        $instance->extra         = $extra;
         $instance->responseClass = Response\SubscribeCustomer::class;
         $instance->instanceType  = 'delete';
         $instance->verb          = 'DELETE';
@@ -219,7 +219,7 @@ class SubscribeCustomer extends RequestBase
         $instance->unsetArray([
             'pg', 'card_number', 'expiry', 'birth', 'pwd_2digit', 'customer_name', 'customer_tel',
             'customer_email', 'customer_addr', 'customer_postcode', 'page', 'from', 'to', 'schedule-status', 'reason',
-            'extra_requester',
+            'extra',
         ]);
 
         return $instance;
@@ -242,7 +242,7 @@ class SubscribeCustomer extends RequestBase
         $instance->unsetArray([
             'customer_uids', 'pg', 'card_number', 'expiry', 'birth', 'pwd_2digit', 'customer_name', 'customer_tel',
             'customer_email', 'customer_addr', 'customer_postcode', 'from', 'to', 'schedule-status', 'reason',
-            'extra_requester',
+            'extra',
         ]);
 
         return $instance;
@@ -269,7 +269,7 @@ class SubscribeCustomer extends RequestBase
         $instance->verb           = 'GET';
         $instance->unsetArray([
             'customer_uids', 'pg', 'card_number', 'expiry', 'birth', 'pwd_2digit', 'customer_name',
-            'customer_tel', 'customer_email', 'customer_addr', 'customer_postcode', 'reason', 'extra_requester',
+            'customer_tel', 'customer_email', 'customer_addr', 'customer_postcode', 'reason', 'extra',
         ]);
 
         return $instance;
@@ -348,9 +348,9 @@ class SubscribeCustomer extends RequestBase
         $this->reason = $reason;
     }
 
-    public function setExtraRequester(string $extra_requester): void
+    public function setExtra(SubscribeCustomerExtra $extra): void
     {
-        $this->extra_requester = $extra_requester;
+        $this->extra = $extra;
     }
 
     /**
@@ -398,8 +398,11 @@ class SubscribeCustomer extends RequestBase
                     $result['query']['reason'] = $this->reason;
                 }
 
-                if (!empty($this->extra_requester)) {
-                    $result['query']['extra[requester]'] = $this->extra_requester;
+                if (!empty($this->extra)) {
+                    $extra_requester = $this->extra->requester;
+                    if (!empty($extra_requester)) {
+                        $result['query']['extra[requester]'] = $extra_requester;
+                    }
                 }
 
                 return $result;

--- a/src/Request/Subscribe/SubscribeCustomerExtra.php
+++ b/src/Request/Subscribe/SubscribeCustomerExtra.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Iamport\RestClient\Request\Subscribe;
+
+use Iamport\RestClient\Request\RequestTrait;
+
+/**
+ * Class SubscribeCustomerExtra.
+ *
+ * @property string $requester
+ */
+class SubscribeCustomerExtra
+{
+    use RequestTrait;
+
+    /**
+     * @var string
+     */
+    protected $requester;
+
+    /**
+     * SubscribeCustomerExtra constructor.
+     */
+    public function __construct()
+    {
+    }
+
+    public function setRequester(string $requester): void
+    {
+        $this->requester = $requester;
+    }
+}

--- a/tests/SubscribeTest.php
+++ b/tests/SubscribeTest.php
@@ -74,7 +74,7 @@ class SubscribeTest extends TestCase
 
         $this->assertEquals('/subscribe/customers/' . self::$customerUid, $subscribeCustomer->path());
         $this->assertEquals('DELETE', $subscribeCustomer->verb());
-        $this->assertEmpty($subscribeCustomer->attributes());
+        $this->assertArrayHasKey('query', $subscribeCustomer->attributes());
 
         $response = $this->iamport->callApi($subscribeCustomer);
 

--- a/tests/SubscribeTest.php
+++ b/tests/SubscribeTest.php
@@ -7,6 +7,7 @@ use Iamport\RestClient\Request\CardInfo;
 use Iamport\RestClient\Request\Subscribe\Schedule;
 use Iamport\RestClient\Request\Subscribe\SubscribeAgain;
 use Iamport\RestClient\Request\Subscribe\SubscribeCustomer;
+use Iamport\RestClient\Request\Subscribe\SubscribeCustomerExtra;
 use Iamport\RestClient\Request\Subscribe\SubscribeInquiry;
 use Iamport\RestClient\Request\Subscribe\SubscribeOnetime;
 use Iamport\RestClient\Request\Subscribe\SubscribeSchedule;
@@ -71,6 +72,22 @@ class SubscribeTest extends TestCase
     public function delete_subscribe_customer()
     {
         $subscribeCustomer = SubscribeCustomer::delete(self::$customerUid);
+
+        $this->assertEquals('/subscribe/customers/' . self::$customerUid, $subscribeCustomer->path());
+        $this->assertEquals('DELETE', $subscribeCustomer->verb());
+        $this->assertArrayHasKey('query', $subscribeCustomer->attributes());
+
+        $response = $this->iamport->callApi($subscribeCustomer);
+
+        $this->assertInstanceOf('Iamport\RestClient\Result', $response);
+    }
+
+    /** @test */
+    public function delete_subscribe_customer_with_optional_parameters()
+    {
+        $extra = new SubscribeCustomerExtra();
+        $extra->requester = '삭제 요청자';
+        $subscribeCustomer = SubscribeCustomer::delete(self::$customerUid, '삭제 사유', $extra);
 
         $this->assertEquals('/subscribe/customers/' . self::$customerUid, $subscribeCustomer->path());
         $this->assertEquals('DELETE', $subscribeCustomer->verb());


### PR DESCRIPTION
## 🌏 iamport-rest-client-php PR 🌏

### PR 요약
- [빌링키 삭제 API](https://api.iamport.kr/#!/subscribe.customer/customer_delete) 요청 파라미터 중 `reason`, `extra[requester]` 파라미터(Optional)를 지원하도록 수정하였습니다.

### 변경된 부분 👍
- SubscribeCustomer 클래스에 `$reason`, `$extra` 멤버 필드를 추가하여 delete 메서드에서 api 요청 시 전달하도록 수정, 그 외 메서드에서 추가된 필드에 영향을 받지 않도록 수정하였습니다.
- `extra[]` 파라미터를 지원하기 위한 SubscribeCustomerExtra 클래스가 추가되었습니다.
- SubscribeTest::delete_subscribe_customer() 에서 기존 query 파라미터가 없어야 테스트에 통과하는 부분이 query 파라미터가 있어야 통과하도록 변경되었습니다.
- SubscribeTest::delete_subscribe_customer_with_optional_parameters() 테스트 케이스가 추가되었습니다.
- customerDelete.php 빌링키 삭제 예제가 수정되었습니다.

### 영향을 받는 다른 컴포넌트 🕸
None

### 집중해서 리뷰할 곳 💡
- SubscribeCustomer 클래스를 봐주시면 좋을 것 같습니다. `$reason`, `$extra` 멤버 필드를 추가하여 delete 메서드 및 그 외 다른 모든 메서드에 영향이 있습니다.
- `extra[]` 파라미터를 지원하기 위해 SubscribeCustomerExtra 클래스를 추가했습니다. 해당 클래스의 네이밍을 좀 고민했는데 혹시 더 나은 방법이나 이름이 있다면 의견 부탁드립니다.

### 테스트 ⚒
- `composer test` 통과 확인
-  API 경로를 로컬로 변경하여 빌링키 삭제 api 호출시 **reason**, **extra[requester]** 파라미터가 정상적으로 전달되는지 api-iamport에서 로깅하여 확인

### 참고링크  🎫
- https://chai-finance.slack.com/archives/C01FJSM3XC5/p1651650069074949

### Due Date: 2022-05-09, 사실 ASAP 입니다
