### PR TITLE
Fix/add parameter support cancel payment

### DIFF
--- a/example/payment/cancel.php
+++ b/example/payment/cancel.php
@@ -4,6 +4,7 @@ require_once '../../vendor/autoload.php';
 
 use Iamport\RestClient\Iamport;
 use Iamport\RestClient\Request\CancelPayment;
+use Iamport\RestClient\Request\CancelPaymentExtra;
 
 $iamport = new Iamport('imp_apikey', 'ekKoeW8RyKuT0zgaZsUtXXTLQ4AhPFW3ZGseDA6bkA5lamv9OqDMnxyeB9wqOsuO9W3Mx9YSJ4dTqJ3f');
 
@@ -11,6 +12,8 @@ $iamport = new Iamport('imp_apikey', 'ekKoeW8RyKuT0zgaZsUtXXTLQ4AhPFW3ZGseDA6bkA
 $merchant_uid        = filter_input(INPUT_POST, 'merchant_uid', FILTER_SANITIZE_STRING);
 $reason              = filter_input(INPUT_POST, 'reason', FILTER_SANITIZE_STRING);
 $cancelRequestAmount = filter_input(INPUT_POST, 'cancel_request_amount', FILTER_SANITIZE_STRING);
+$extra_requester     = filter_input(INPUT_POST, 'extra_requester', FILTER_SANITIZE_STRING);
+
 
 // TODO : 아래 가맹점 DB 접근 코드는 예시를 돕고자 작성된 샘플코드로 실제 가맹점의 환경에 맞게 직접 작성하셔야 됩니다.
 // 가맹점 DB에서 환불할 결제 정보 조회
@@ -39,6 +42,14 @@ $request->reason         = $data['reason'];
 $request->refund_holder  = '환불될 가상계좌 예금주';
 $request->refund_bank    = '환불될 가상계좌 은행코드';
 $request->refund_account = '환불될 가상계좌 번호';
+
+$extra = new CancelPaymentExtra();
+if ( in_array($extra_requester, ['admin', 'customer'])) {
+    // API를 호출하는 출처 (optional)
+    $extra->requester = $extra_requester;
+}
+
+$request->extra          = $extra;
 $result                  = $iamport->callApi($request);
 
 if ($result->isSuccess()) {

--- a/example/payment/cancel.php
+++ b/example/payment/cancel.php
@@ -14,7 +14,6 @@ $reason              = filter_input(INPUT_POST, 'reason', FILTER_SANITIZE_STRING
 $cancelRequestAmount = filter_input(INPUT_POST, 'cancel_request_amount', FILTER_SANITIZE_STRING);
 $extra_requester     = filter_input(INPUT_POST, 'extra_requester', FILTER_SANITIZE_STRING);
 
-
 // TODO : 아래 가맹점 DB 접근 코드는 예시를 돕고자 작성된 샘플코드로 실제 가맹점의 환경에 맞게 직접 작성하셔야 됩니다.
 // 가맹점 DB에서 환불할 결제 정보 조회
 $pdo          = new PDO('dsn', 'db username', 'db password');

--- a/example/payment/cancel.php
+++ b/example/payment/cancel.php
@@ -2,6 +2,7 @@
 
 require_once '../../vendor/autoload.php';
 
+use Iamport\RestClient\Enum\Naver\CancelPaymentRequester;
 use Iamport\RestClient\Iamport;
 use Iamport\RestClient\Request\CancelPayment;
 use Iamport\RestClient\Request\CancelPaymentExtra;
@@ -43,9 +44,11 @@ $request->refund_bank    = '환불될 가상계좌 은행코드';
 $request->refund_account = '환불될 가상계좌 번호';
 
 $extra = new CancelPaymentExtra();
-if ( in_array($extra_requester, ['admin', 'customer'])) {
-    // API를 호출하는 출처 (optional)
-    $extra->requester = $extra_requester;
+// 취소 요청자, API를 호출하는 출처 (optional)
+if ($extra_requester === 'admin') {
+    $extra->requester = CancelPaymentRequester::ADMIN;
+} else if ($extra_requester === 'customer'){
+    $extra->requester = CancelPaymentRequester::CUSTOMER;
 }
 
 $request->extra          = $extra;

--- a/src/Enum/Naver/CancelPaymentRequester.php
+++ b/src/Enum/Naver/CancelPaymentRequester.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Iamport\RestClient\Enum\Naver;
+
+use Iamport\RestClient\Enum\Enum;
+
+/**
+ * Class CancelPaymentRequester.
+ */
+class CancelPaymentRequester extends Enum
+{
+    public const CUSTOMER = 'customer';
+    public const ADMIN    = 'admin';
+
+
+    /**
+     * Enum의 설명을 가져옵니다.
+     *
+     * @param string $value
+     */
+    public static function getDescription($value): ?string
+    {
+        switch ($value) {
+            case self::CUSTOMER:
+                return '구매자';
+            case self::ADMIN:
+                return '가맹점 관리자';
+            default:
+                return null;
+        }
+    }
+}

--- a/src/Request/CancelPayment.php
+++ b/src/Request/CancelPayment.php
@@ -17,6 +17,8 @@ use Iamport\RestClient\Response;
  * @property string $refund_holder
  * @property string $refund_bank
  * @property string $refund_account
+ * @property string $refund_tel
+ * @property CancelPaymentExtra $extra
  */
 class CancelPayment extends RequestBase
 {
@@ -66,6 +68,16 @@ class CancelPayment extends RequestBase
      * @var string 환불계좌 계좌번호(가상계좌취소시 필수)
      */
     protected $refund_account;
+
+    /**
+     * @var string 환불계좌 예금주 연락처(가상계좌취소,스마트로 PG사 인경우 필수 )
+     */
+    protected $refund_tel;
+
+    /**
+     * @var CancelPaymentExtra
+     */
+    protected $extra;
 
     /**
      * CancelPayment constructor.
@@ -146,6 +158,16 @@ class CancelPayment extends RequestBase
         $this->refund_account = $refund_account;
     }
 
+    public function setRefundTel(string $refund_tel): void
+    {
+        $this->refund_tel = $refund_tel;
+    }
+
+    public function setExtra(CancelPaymentExtra $extra): void
+    {
+        $this->extra = $extra;
+    }
+
     /**
      * 주문취소.
      * [POST] /payments/cancel.
@@ -157,8 +179,14 @@ class CancelPayment extends RequestBase
 
     public function attributes(): array
     {
+        $result = $this->toArray();
+
+        if ($this->extra instanceof CancelPaymentExtra) {
+            $result['extra'] = $this->extra->toArray();
+        }
+
         return [
-            'body' => json_encode($this->toArray()),
+            'body' => json_encode($result),
         ];
     }
 

--- a/src/Request/CancelPaymentExtra.php
+++ b/src/Request/CancelPaymentExtra.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Iamport\RestClient\Request;
+
+use Iamport\RestClient\Request\RequestTrait;
+
+/**
+ * Class CancelPaymentExtra
+ *
+ * @property string $requester
+ */
+class CancelPaymentExtra
+{
+    use RequestTrait;
+
+    /**
+     * @var string API를 호출하는 출처 [ customer, admin ]
+     */
+    protected $requester;
+
+    /**
+     * CustomerExtra constructor.
+     */
+    public function __construct()
+    {
+    }
+
+    public function setRequester(string $requester): void
+    {
+        $this->requester = $requester;
+    }
+}

--- a/tests/PaymentTest.php
+++ b/tests/PaymentTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Iamport\RestClient\Request\CancelPayment;
+use Iamport\RestClient\Request\CancelPaymentExtra;
 use Iamport\RestClient\Request\Payment;
 use Iamport\RestClient\Test\IamportTestTrait;
 use PHPUnit\Framework\TestCase;
@@ -81,6 +82,10 @@ class PaymentTest extends TestCase
         $cancelPayment->refund_holder  = '환불될 가상계좌 예금주';
         $cancelPayment->refund_bank    = '환불될 가상계좌 은행코드';
         $cancelPayment->refund_account = '환불될 가상계좌 번호';
+        $cancelPayment->refund_tel     = "01012341234";
+        $extra                         = new CancelPaymentExtra();
+        $extra->requester              = 'admin';
+        $cancelPayment->setExtra($extra);
 
         $this->assertSame($cancelPayment->imp_uid, self::$impUid);
         $this->assertEquals('/payments/cancel/', $cancelPayment->path());
@@ -103,6 +108,10 @@ class PaymentTest extends TestCase
         $cancelPayment->refund_holder  = '환불될 가상계좌 예금주';
         $cancelPayment->refund_bank    = '환불될 가상계좌 은행코드';
         $cancelPayment->refund_account = '환불될 가상계좌 번호';
+        $cancelPayment->refund_tel     = "01012341234";
+        $extra                         = new CancelPaymentExtra();
+        $extra->requester              = 'admin';
+        $cancelPayment->setExtra($extra);
 
         $this->assertSame($cancelPayment->merchant_uid, self::$merchantUid);
         $this->assertEquals('/payments/cancel/', $cancelPayment->path());

--- a/tests/PaymentTest.php
+++ b/tests/PaymentTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Iamport\RestClient\Enum\Naver\CancelPaymentRequester;
 use Iamport\RestClient\Request\CancelPayment;
 use Iamport\RestClient\Request\CancelPaymentExtra;
 use Iamport\RestClient\Request\Payment;
@@ -84,7 +85,7 @@ class PaymentTest extends TestCase
         $cancelPayment->refund_account = '환불될 가상계좌 번호';
         $cancelPayment->refund_tel     = "01012341234";
         $extra                         = new CancelPaymentExtra();
-        $extra->requester              = 'admin';
+        $extra->requester              = CancelPaymentRequester::ADMIN;
         $cancelPayment->setExtra($extra);
 
         $this->assertSame($cancelPayment->imp_uid, self::$impUid);
@@ -110,7 +111,7 @@ class PaymentTest extends TestCase
         $cancelPayment->refund_account = '환불될 가상계좌 번호';
         $cancelPayment->refund_tel     = "01012341234";
         $extra                         = new CancelPaymentExtra();
-        $extra->requester              = 'admin';
+        $extra->requester              = CancelPaymentRequester::ADMIN;
         $cancelPayment->setExtra($extra);
 
         $this->assertSame($cancelPayment->merchant_uid, self::$merchantUid);


### PR DESCRIPTION
## 🌏 iamport-rest-client-php PR 🌏

### PR 요약
- 결제취소 API 요청 파라미터 `refund_tel`, `extra[requester]` 파라미터를 지원하도록 수정하였습니다.

### 변경된 부분 👍
- `CancelPayment` 클래스에 `$refund_tel`, `$extra` 멤버 추가
- `extra[]` 파라미터를 지원하기 위한 `CancelPaymentExtra` 클래스가 추가되었습니다.
- 관련  테스트 케이스, 예제 수정 

### 영향을 받는 다른 컴포넌트 🕸
None

### 집중해서 리뷰할 곳 💡
- [직전 작업](https://github.com/iamport/iamport-rest-client-php/pull/9)과 유사한 작업입니다. 

### 테스트 ⚒
- `composer test` 통과 확인
-  API 경로를 로컬로 변경하여 결제 삭제 api 호출시 **refund**, **extra[requester]** 파라미터가 정상적으로 전달되는지 api-iamport에서 로깅하여 확인

### 참고링크  🎫
- https://chai-finance.slack.com/archives/C01FJSM3XC5/p1651650069074949

### Due Date: 2022-05-16